### PR TITLE
feat: added banner before help

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ fn main() {
     let matches = App::new("ietf")
         .version("0.1.0")
         .about("A program to read RFCs in the terminal.")
+        .before_help("██▄██ ▄▄█▄ ▄█ ▄▄\n██ ▄█ ▄▄██ ██ ▄█\n█▄▄▄█▄▄▄██▄██▄██\n▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀")
         .arg(
             Arg::with_name("Number")
                 .short("n")


### PR DESCRIPTION
I added the banner to the cli output before the help, so it looks like:

```console
> ietf -h 
██▄██ ▄▄█▄ ▄█ ▄▄
██ ▄█ ▄▄██ ██ ▄█
█▄▄▄█▄▄▄██▄██▄██
▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀

ietf 0.1.0
A program to read RFCs in the terminal.

USAGE:
    ietf [OPTIONS] [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -n, --number <serial>    RFC Serial Number

SUBCOMMANDS:
    help      Prints this message or the help of the given subcommand(s)
    update    Update RFC Index
```